### PR TITLE
Fix electron BrowserWindow hook

### DIFF
--- a/lib/twitch.init.js
+++ b/lib/twitch.init.js
@@ -30,7 +30,7 @@
     }
     else if (options.electron) {
       gui_type = "electron";
-      BrowserWindow = require('remote').require('browser-window');
+      BrowserWindow = require('electron').remote.BrowserWindow;
     }
 
     initSession(options.session, callback);

--- a/lib/twitch.init.js
+++ b/lib/twitch.init.js
@@ -30,7 +30,7 @@
     }
     else if (options.electron) {
       gui_type = "electron";
-      BrowserWindow = require("browser-window");
+      BrowserWindow = require('remote').require('browser-window');
     }
 
     initSession(options.session, callback);


### PR DESCRIPTION
The require needs a require for remote first to function correctly. (Electron handles the rest)