### PR TITLE
Replace deprecated electron URL functions

### DIFF
--- a/lib/twitch.popup.js
+++ b/lib/twitch.popup.js
@@ -47,9 +47,9 @@
 			"node-integration": false
 		});
 
-		win.loadUrl(url);
+		win.loadURL(url);
 		win.webContents.on('did-finish-load', function() {
-			var location = URL.parse(win.webContents.getUrl());
+			var location = URL.parse(win.webContents.getURL());
 
 			if (location.hostname == 'api.twitch.tv' && location.pathname == '/kraken/') {
         config.session = parseFragment(location.hash);


### PR DESCRIPTION
Replaced Url with URL, because Url is deprecated. 
URL is now the valid way to handle the same functionality.