### PR TITLE
Repair login process

### DIFF
--- a/lib/twitch.auth.js
+++ b/lib/twitch.auth.js
@@ -16,7 +16,7 @@ var SESSION_KEY = 'twitch_oauth_session';
  * @private @method updateSession
  */
 function updateSession(callback) {
-  core.api({method: '/'}, function(err, response) {
+  core.api({method: ''}, function(err, response) {
     var session;
     if (err) {
       core.log('error encountered updating session:', err);

--- a/twitch.js
+++ b/twitch.js
@@ -21,20 +21,7 @@ exports.init = init.init;
 exports.api = core.api;
 
 // Events
-exports.events = {
-  on: core.events.on,
-  addListener: core.events.on,
-  once: core.events.once,
-  removeListener: core.events.removeListener,
-  getMaxListeners: core.events.getMaxListeners,
-  listenerCount: core.events.listenerCount
-};
-exports.on = core.events.on;
-exports.addListener = core.events.on;
-exports.once = core.events.once;
-exports.removeListener = core.events.removeListener;
-exports.getMaxListeners = core.events.getMaxListeners;
-exports.listenerCount = core.events.listenerCount;
+exports.events = core.events;
 
 
 // Auth


### PR DESCRIPTION
API fails with 404 because the URL generated is /kraken//?
Removing the '/' character generates correct url '/kraken/?'